### PR TITLE
drop explicitly defined slaves from state examples

### DIFF
--- a/devel/design/networking-api.md
+++ b/devel/design/networking-api.md
@@ -509,16 +509,6 @@ specified.
 
 ```yaml
 interfaces:
-- name: eth2
-  type: ethernet
-  state: up
-  ipv4:
-    enabled: false
-- name: eth3
-  type: ethernet
-  state: up
-  ipv4:
-    enabled: false
 - name: bond99
   type: bond
   state: up
@@ -545,11 +535,6 @@ The bridge has spanning tree (stp) enabled.
 
 ```yaml
 interfaces:
-- name: eth3
-  type: ethernet
-  state: up
-  ipv4:
-    enabled: false
 - name: ovs-br0
   type: ovs-bridge
   state: up

--- a/examples.md
+++ b/examples.md
@@ -82,16 +82,6 @@ specified.
 
 ```yaml
 interfaces:
-- name: eth2
-  type: ethernet
-  state: up
-  ipv4:
-    enabled: false
-- name: eth3
-  type: ethernet
-  state: up
-  ipv4:
-    enabled: false
 - name: bond99
   type: bond
   state: up
@@ -118,11 +108,6 @@ The bridge has spanning tree (stp) enabled.
 
 ```yaml
 interfaces:
-- name: eth3
-  type: ethernet
-  state: up
-  ipv4:
-    enabled: false
 - name: ovs-br0
   type: ovs-bridge
   state: up
@@ -168,9 +153,6 @@ interfaces:
 ```yaml
 ---
 interfaces:
-  - name: eth1
-    type: ethernet
-    state: up
   - name: linux-br0
     type: linux-bridge
     state: up


### PR DESCRIPTION
Those definitions are not needed. It is confusing users (including
me). Let's keep the API as simple as possible.

Signed-off-by: Petr Horacek <phoracek@redhat.com>