### PR TITLE
Add VXLAN missing example

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -154,7 +154,7 @@ interfaces:
     enabled: false
 ```
 
-## Interface: VLAN
+## Interfaces: VLAN
 
 ```yaml
 ---
@@ -165,6 +165,20 @@ interfaces:
     vlan:
       base-iface: eth1
       id: 101
+```
+
+## Interfaces: VXLAN
+
+```yaml
+---
+interfaces:
+  - name: eth1.101
+    type: vxlan
+    state: up
+    vxlan:
+      base-iface: eth1
+      id: 101
+      remote: 192.0.2.2
 ```
 
 ## Interface: Linux Bridge

--- a/index.md
+++ b/index.md
@@ -115,6 +115,7 @@ Want to see nmstate in action? Check out the [demos](./demos.md).
 - [ethernet](./examples.md#interfaces-ethernet)
 - [bond](./examples.md#interfaces-bond)
 - [Vlan](./examples.md#interfaces-vlan)
+- [Vxlan](./examples.md#interfaces-vxlan)
 - [Linux bridge](./examples.md#interface-linux-bridge)
 - [ovs-bridge](./examples.md#interfaces-ovs-bridge)
 - [dummy](./examples.md#interfaces-dummy)


### PR DESCRIPTION
Also fix a typo in VLAN example title.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>