### PR TITLE
networking-api.md: add a preamble

### DIFF
--- a/devel/design/networking-api.md
+++ b/devel/design/networking-api.md
@@ -1,5 +1,9 @@
 # Linux Networking API
 
+This document was created over the year 2018, much before this git repository
+and web site were a reality. It presents the original design of Nmstate and
+provides the motiviation for its existence.
+
 ## OVERVIEW
 Networking has always been a major subsystem in the Linux ecosystem. Its
 functionality is used broadly across domains, from connecting a local host to


### PR DESCRIPTION
The networking-api design doc feels a bit old and out of context. I think that it is important to tell its current readership that it has existed before the web site and the nmstate upstream project.