### PR TITLE
index: Add projects related to nmstate

### DIFF
--- a/index.md
+++ b/index.md
@@ -70,6 +70,10 @@ Visit the [examples page](./examples.md) to see what it can do.
 - [Plugin Design](./devel/plugin.md)
 - [Varlink support for libnmstate](./devel/varlink-libnmstate.md)
 
+## Related projects
+- [kubernetes-nmstate](https://nmstate.io/kubernetes-nmstate)
+- [nmpolicy](https://nmstate.io/nmpolicy)
+
 ## Contacts
 - You can find us on #nmstate IRC channel on [Libera](https://libera.chat/).
   The maintainers are Gris, edwardh and ffmancera, please feel free to ask


### PR DESCRIPTION
Currectly there are a pair of projects under nmstate umbrella that have
their own docs under "nmstate.io". This change add new section to link
to them.

Signed-off-by: Quique Llorente <ellorent@redhat.com>