### PR TITLE
docs, bond: fix the bond attribute to define its ports

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -116,7 +116,7 @@ interfaces:
     mode: balance-rr
     options:
       miimon: '140'
-    ports:
+    port:
     - eth3
     - eth2
 


### PR DESCRIPTION
When trying to provision the provided bond example, it fails with the
following error:
```
[root@fc35 ~]# nmstatectl apply bond-config.yaml
serde_yaml::Error: unknown field `ports`, expected one of `mode`, `options`, `port`
```

Using the correct API fixes it - `s/ports/port/`.

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>