### PR TITLE
Add nm-configurator

### DIFF
--- a/index.md
+++ b/index.md
@@ -79,6 +79,7 @@ interfaces:
 ## Related projects
 - [kubernetes-nmstate](https://nmstate.io/kubernetes-nmstate)
 - [nmpolicy](https://nmstate.io/nmpolicy)
+- [nm-configurator](https://github.com/suse-edge/nm-configurator)
 
 ## Contacts
 - You can find us on Matrix room: [`#nmstate:fedora.im`][matrix_room_url]


### PR DESCRIPTION
[SUSE Edge Networking](https://documentation.suse.com/suse-edge/3.3/html/edge/components-nmc.html) uses nmstate under the hood. The upstream project [nm-configurator](https://github.com/suse-edge/nm-configurator) (or nmc) is a CLI tool which makes it easy to generate and apply NetworkManager configurations using nmstate definitions.